### PR TITLE
fix: use relative url for link-social to prevent cors errors

### DIFF
--- a/.changeset/fix-cors-link-social.md
+++ b/.changeset/fix-cors-link-social.md
@@ -1,0 +1,5 @@
+---
+'@groupi/web': patch
+---
+
+Fix CORS error when linking Discord or Google accounts by using a relative URL instead of an absolute URL constructed from NEXT_PUBLIC_BASE_URL

--- a/.changeset/simplify-email-invite-workflow.md
+++ b/.changeset/simplify-email-invite-workflow.md
@@ -1,0 +1,5 @@
+---
+'@groupi/web': patch
+---
+
+Simplify email invite dialog to a single-step workflow: add emails to list and send invites in one action, removing the confusing intermediate "Save" step and "Pending" badge

--- a/packages/web/app/(settings)/settings/components/linked-accounts-list.tsx
+++ b/packages/web/app/(settings)/settings/components/linked-accounts-list.tsx
@@ -69,11 +69,9 @@ export function LinkedAccountsList({
     try {
       // Use Better Auth's linkSocial method
       // We need to intercept the redirect and open it in a new tab
-      const baseURL =
-        process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
-
-      // Try to get the redirect URL by making a fetch request with redirect: 'manual'
-      const response = await fetch(`${baseURL}/api/auth/link-social`, {
+      // Use relative URL to guarantee same-origin (avoids CORS issues from
+      // NEXT_PUBLIC_BASE_URL mismatches like www vs non-www)
+      const response = await fetch('/api/auth/link-social', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/web/components/email-invite-item.tsx
+++ b/packages/web/components/email-invite-item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { X, Mail, Check, Clock, Users } from 'lucide-react';
+import { X, Mail, Check, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
@@ -65,12 +65,6 @@ export function EmailInviteItem({
           >
             <Check className='size-3 mr-1' />
             Sent
-          </Badge>
-        )}
-        {emailStatus === 'pending' && (
-          <Badge variant='outline' className='text-muted-foreground'>
-            <Clock className='size-3 mr-1' />
-            Pending
           </Badge>
         )}
 

--- a/packages/web/components/email-invites-dialog.tsx
+++ b/packages/web/components/email-invites-dialog.tsx
@@ -15,7 +15,6 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
-import { Icons } from '@/components/icons';
 import {
   LocalEmailInviteItem,
   EmailInviteItem,
@@ -100,8 +99,6 @@ export function EmailInvitesDialog({
       (invite: BaseInvite): invite is InviteWithEmail => invite.hasEmail
     );
   }, [inviteData]);
-
-  const pendingCount = inviteData?.pendingEmailCount || 0;
 
   // Handle manual add
   const handleManualAdd = useCallback(() => {
@@ -242,34 +239,22 @@ export function EmailInvitesDialog({
     [deleteInvites]
   );
 
-  // Handle save (create invites on server)
-  const handleSave = useCallback(async () => {
-    if (localInvites.length === 0) return;
-
-    await createEmailInvites({
-      invites: localInvites,
-      customMessage: customMessage.trim() || undefined,
-    });
-
-    setLocalInvites([]);
-  }, [localInvites, customMessage, createEmailInvites]);
-
-  // Handle send emails
-  const handleSendEmails = useCallback(async () => {
+  // Handle send invites (create + send in one action)
+  const handleSendInvites = useCallback(async () => {
     setIsSending(true);
     try {
-      // First save any unsaved invites
       if (localInvites.length > 0) {
-        await handleSave();
+        await createEmailInvites({
+          invites: localInvites,
+          customMessage: customMessage.trim() || undefined,
+        });
+        setLocalInvites([]);
       }
       await sendEmailInvites();
     } finally {
       setIsSending(false);
     }
-  }, [localInvites.length, handleSave, sendEmailInvites]);
-
-  // Calculate total pending (local + server pending)
-  const totalPending = localInvites.length + pendingCount;
+  }, [localInvites, customMessage, createEmailInvites, sendEmailInvites]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -577,22 +562,10 @@ John Doe <john@example.com>; Jane Smith <jane@example.com>`}
         </div>
 
         {/* Footer with actions */}
-        <div className='flex items-center justify-between pt-4 border-t gap-4'>
-          {/* Save local invites button (if there are unsaved) */}
-          {localInvites.length > 0 && (
-            <Button variant='outline' onClick={handleSave}>
-              <Icons.check className='size-4 mr-2' />
-              Save {localInvites.length} invite
-              {localInvites.length !== 1 ? 's' : ''}
-            </Button>
-          )}
-
-          <div className='flex-1' />
-
-          {/* Send emails button */}
+        <div className='flex items-center justify-end pt-4 border-t gap-4'>
           <Button
-            onClick={handleSendEmails}
-            disabled={totalPending === 0 || isSending}
+            onClick={handleSendInvites}
+            disabled={localInvites.length === 0 || isSending}
             className='min-w-[150px]'
           >
             {isSending ? (
@@ -603,8 +576,8 @@ John Doe <john@example.com>; Jane Smith <jane@example.com>`}
             ) : (
               <>
                 <Send className='size-4 mr-2' />
-                Send emails
-                {totalPending > 0 && ` (${totalPending})`}
+                Send invites
+                {localInvites.length > 0 && ` (${localInvites.length})`}
               </>
             )}
           </Button>


### PR DESCRIPTION
## Summary
- Fix CORS error when linking Discord/Google accounts in production
- The `link-social` fetch used an absolute URL from `NEXT_PUBLIC_BASE_URL`, causing cross-origin failures when the env var didn't exactly match the browsing origin (e.g., `www` vs non-`www`)
- Switch to a relative URL (`/api/auth/link-social`) to guarantee same-origin requests

## Test plan
- [ ] Deploy to preview and test Discord account linking from settings page
- [ ] Verify no CORS errors in browser console
- [ ] Verify the OAuth redirect opens in a new tab as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)