### PR TITLE
fix: prevent double-join on invite page and harden backend

### DIFF
--- a/.changeset/fix-invite-double-join.md
+++ b/.changeset/fix-invite-double-join.md
@@ -1,0 +1,6 @@
+---
+'@groupi/web': patch
+'@groupi/convex': patch
+---
+
+Fix invite page allowing join button press before redirect when user is already an event member. The button is now disabled during the membership check, and the backend gracefully handles duplicate join attempts instead of erroring.

--- a/convex/invites/mutations.ts
+++ b/convex/invites/mutations.ts
@@ -253,7 +253,22 @@ export const acceptInvite = mutation({
       .first();
 
     if (existingMembership) {
-      throw new Error('You are already a member of this event');
+      const event = await ctx.db.get(invite.eventId);
+      return {
+        membership: {
+          id: existingMembership._id,
+          eventId: existingMembership.eventId,
+          role: existingMembership.role,
+          rsvpStatus: existingMembership.rsvpStatus,
+        },
+        event: {
+          id: event!._id,
+          title: event!.title,
+          description: event!.description,
+          location: event!.location,
+        },
+        alreadyMember: true,
+      };
     }
 
     // Check if user is banned from this event
@@ -329,6 +344,7 @@ export const acceptInvite = mutation({
         description: event!.description,
         location: event!.location,
       },
+      alreadyMember: false,
     };
   },
 });

--- a/packages/web/app/(invite)/invite/[inviteId]/components/invite-accept.tsx
+++ b/packages/web/app/(invite)/invite/[inviteId]/components/invite-accept.tsx
@@ -22,9 +22,11 @@ initApi();
 
 export function AcceptInviteForm({
   inviteId,
+  isAlreadyMember,
 }: {
   inviteId: string;
   eventId: string;
+  isAlreadyMember: boolean;
 }) {
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -111,6 +113,7 @@ export function AcceptInviteForm({
         onClick={handleAccept}
         isLoading={isLoading}
         loadingText='Accepting...'
+        disabled={isAlreadyMember}
       >
         Accept invite
       </Button>

--- a/packages/web/app/(invite)/invite/[inviteId]/components/invite-details.tsx
+++ b/packages/web/app/(invite)/invite/[inviteId]/components/invite-details.tsx
@@ -211,7 +211,11 @@ export function InviteDetails({ inviteId }: { inviteId: string }) {
           )}
         </CardContent>
         <CardFooter>
-          <AcceptInviteForm inviteId={inviteId} eventId={event.id} />
+          <AcceptInviteForm
+            inviteId={inviteId}
+            eventId={event.id}
+            isAlreadyMember={inviteData.isAlreadyMember}
+          />
         </CardFooter>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

- **Disable join button during membership check**: When a user lands on an invite page and is already a member of the event, the "Accept invite" button is now disabled immediately while the redirect to the event page is in progress. Previously, the button was clickable during this window, allowing users to trigger a join mutation that would error out.
- **Graceful backend handling**: The `acceptInvite` mutation no longer throws when the user is already a member. Instead, it returns the existing membership data with an `alreadyMember: true` flag, so even if the frontend check is bypassed (race condition, direct API call), the request succeeds without side effects.

## Changes

- `convex/invites/mutations.ts` — Return existing membership gracefully instead of throwing `"You are already a member of this event"`
- `packages/web/.../invite-accept.tsx` — Accept `isAlreadyMember` prop, disable button when true
- `packages/web/.../invite-details.tsx` — Pass `isAlreadyMember` from query data to `AcceptInviteForm`

## Test plan

- [x] Open an invite link while already a member of the event — button should be disabled, redirect should happen
- [x] Open an invite link while NOT a member — button should work normally
- [x] Call `acceptInvite` mutation directly for an event you're already in — should return success with `alreadyMember: true` instead of erroring