### PR TITLE
refactor(convex): standard REST API response format

### DIFF
--- a/.claude/rules/addons.md
+++ b/.claude/rules/addons.md
@@ -642,9 +642,9 @@ Custom addon automations run via `TrustedAddonContext` because they need schedul
 
 ## REST API Rules
 
-### Rule 33: REST API follows standard response format
+### Rule 33: REST API follows standard REST conventions
 
-All responses use: `{ success: boolean, data?: ..., error?: { code, message } }`.
+Success responses return data directly (no envelope). Errors use `{ error: { code, message } }`. Deletes return 204 No Content.
 
 ### Rule 34: REST API enforces same auth as Convex mutations
 

--- a/convex/api/v1/index.ts
+++ b/convex/api/v1/index.ts
@@ -69,7 +69,6 @@ function createApiV1App(
     if (err instanceof HTTPException) {
       return c.json(
         {
-          success: false,
           error: {
             code:
               err.status === 401
@@ -86,7 +85,6 @@ function createApiV1App(
     console.error('Unhandled error:', err);
     return c.json(
       {
-        success: false,
         error: {
           code: 'INTERNAL_ERROR',
           message: 'An unexpected error occurred',
@@ -121,11 +119,10 @@ API requests are rate limited. If you exceed the limit, you'll receive a 429 Too
 
 ## Errors
 
-All errors return a consistent JSON format:
+All errors return a consistent JSON format with an appropriate HTTP status code:
 
 \`\`\`json
 {
-  "success": false,
   "error": {
     "code": "ERROR_CODE",
     "message": "Human-readable error message"
@@ -229,7 +226,6 @@ export const handler = httpAction(async (ctx, request) => {
       if (error instanceof HTTPException) {
         return new Response(
           JSON.stringify({
-            success: false,
             error: {
               code: 'UNAUTHORIZED',
               message: error.message,

--- a/convex/api/v1/routes/addons.ts
+++ b/convex/api/v1/routes/addons.ts
@@ -1,9 +1,12 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { requireEventMembership, requireEventRole } from '../middleware/auth';
-import { ErrorResponseSchema, EventIdParamSchema } from '../schemas/common';
+import {
+  ErrorResponseSchema,
+  EventIdParamSchema,
+  MessageResponseSchema,
+} from '../schemas/common';
 import {
   EventAddonParamSchema,
   EventAddonDataKeyParamSchema,
@@ -11,10 +14,9 @@ import {
   UpdateAddonConfigRequestSchema,
   SetAddonDataRequestSchema,
   AddonListResponseSchema,
-  AddonConfigSingleResponseSchema,
+  AddonConfigResponseSchema,
   AddonDataListResponseSchema,
-  AddonDataSingleResponseSchema,
-  AddonSuccessResponseSchema,
+  AddonDataEntrySchema,
 } from '../schemas/addons';
 
 // Type for Hono app with Convex context
@@ -80,13 +82,7 @@ export function createAddonRoutes() {
     const listFn = internal.api.v1.internal.addons.listEventAddons;
     const result = await ctx.runQuery(listFn, { eventId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // POST /events/:eventId/addons/:addonType/enable - Enable addon
@@ -113,7 +109,7 @@ export function createAddonRoutes() {
         description: 'Add-on enabled',
         content: {
           'application/json': {
-            schema: AddonSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -162,20 +158,13 @@ export function createAddonRoutes() {
         error instanceof Error ? error.message : 'Failed to enable add-on';
       return c.json(
         {
-          success: false as const,
           error: { code: 'BAD_REQUEST', message },
         },
         400
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: `Add-on ${addonType} enabled successfully` },
-      },
-      200
-    );
+    return c.json({ message: `Add-on ${addonType} enabled successfully` }, 200);
   });
 
   // POST /events/:eventId/addons/:addonType/disable - Disable addon
@@ -195,7 +184,7 @@ export function createAddonRoutes() {
         description: 'Add-on disabled',
         content: {
           'application/json': {
-            schema: AddonSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -231,10 +220,7 @@ export function createAddonRoutes() {
     await ctx.runMutation(disableFn, { eventId, addonType });
 
     return c.json(
-      {
-        success: true as const,
-        data: { message: `Add-on ${addonType} disabled successfully` },
-      },
+      { message: `Add-on ${addonType} disabled successfully` },
       200
     );
   });
@@ -263,7 +249,7 @@ export function createAddonRoutes() {
         description: 'Add-on config updated',
         content: {
           'application/json': {
-            schema: AddonConfigSingleResponseSchema,
+            schema: AddonConfigResponseSchema,
           },
         },
       },
@@ -312,13 +298,7 @@ export function createAddonRoutes() {
         config,
       });
 
-      return c.json(
-        {
-          success: true as const,
-          data: result,
-        },
-        200
-      );
+      return c.json(result, 200);
     } catch (error) {
       const message =
         error instanceof Error
@@ -326,7 +306,6 @@ export function createAddonRoutes() {
           : 'Failed to update add-on config';
       return c.json(
         {
-          success: false as const,
           error: { code: 'BAD_REQUEST', message },
         },
         400
@@ -387,13 +366,7 @@ export function createAddonRoutes() {
     const getDataFn = internal.api.v1.internal.addons.getAddonData;
     const result = await ctx.runQuery(getDataFn, { eventId, addonType });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // PUT /events/:eventId/addons/:addonType/data/:key - Set addon data entry
@@ -420,7 +393,7 @@ export function createAddonRoutes() {
         description: 'Data entry created or updated',
         content: {
           'application/json': {
-            schema: AddonDataSingleResponseSchema,
+            schema: AddonDataEntrySchema,
           },
         },
       },
@@ -473,15 +446,12 @@ export function createAddonRoutes() {
 
       return c.json(
         {
-          success: true as const,
-          data: {
-            id: result.id,
-            key: result.key,
-            data: result.data,
-            createdBy: result.createdBy,
-            createdAt: result.createdAt,
-            updatedAt: result.updatedAt,
-          },
+          id: result.id,
+          key: result.key,
+          data: result.data,
+          createdBy: result.createdBy,
+          createdAt: result.createdAt,
+          updatedAt: result.updatedAt,
         },
         200
       );
@@ -490,7 +460,6 @@ export function createAddonRoutes() {
         error instanceof Error ? error.message : 'Failed to set add-on data';
       return c.json(
         {
-          success: false as const,
           error: { code: 'BAD_REQUEST', message },
         },
         400
@@ -511,16 +480,8 @@ export function createAddonRoutes() {
       params: EventAddonDataKeyParamSchema,
     },
     responses: {
-      200: {
+      204: {
         description: 'Data entry deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
       },
       401: {
         description: 'Unauthorized',
@@ -558,20 +519,13 @@ export function createAddonRoutes() {
         error instanceof Error ? error.message : 'Failed to delete add-on data';
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message },
         },
         403
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Data entry deleted successfully' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   return app;

--- a/convex/api/v1/routes/admin.ts
+++ b/convex/api/v1/routes/admin.ts
@@ -1,8 +1,11 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
-import { ErrorResponseSchema, EventIdParamSchema } from '../schemas/common';
+import {
+  ErrorResponseSchema,
+  EventIdParamSchema,
+  MessageResponseSchema,
+} from '../schemas/common';
 import {
   AdminUserListResponseSchema,
   AdminEventListResponseSchema,
@@ -75,7 +78,6 @@ export function createAdminRoutes() {
     if (!admin) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message: 'Admin privileges required' },
         },
         403
@@ -87,13 +89,7 @@ export function createAdminRoutes() {
     const listFn = internal.api.v1.internal.admin.listUsers;
     const result = await ctx.runQuery(listFn, {});
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.users,
-      },
-      200
-    );
+    return c.json(result.users, 200);
   });
 
   // DELETE /admin/users/:userId - Delete user
@@ -108,16 +104,8 @@ export function createAdminRoutes() {
       params: UserIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'User deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
+      204: {
+        description: 'User deleted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -155,7 +143,6 @@ export function createAdminRoutes() {
     if (!admin) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message: 'Admin privileges required' },
         },
         403
@@ -168,19 +155,12 @@ export function createAdminRoutes() {
       const deleteFn = internal.api.v1.internal.admin.deleteUser;
       await ctx.runMutation(deleteFn, { userId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'User deleted successfully' },
-        },
-        200
-      );
+      return c.body(null, 204);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to delete user';
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message },
         },
         404
@@ -211,10 +191,7 @@ export function createAdminRoutes() {
         description: 'Role updated',
         content: {
           'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -255,7 +232,6 @@ export function createAdminRoutes() {
     if (!admin) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message: 'Admin privileges required' },
         },
         403
@@ -268,19 +244,12 @@ export function createAdminRoutes() {
       const setRoleFn = internal.api.v1.internal.admin.setUserRole;
       await ctx.runMutation(setRoleFn, { userId, role: body.role });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: `User role updated to ${body.role}` },
-        },
-        200
-      );
+      return c.json({ message: `User role updated to ${body.role}` }, 200);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to update role';
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message },
         },
         404
@@ -332,7 +301,6 @@ export function createAdminRoutes() {
     if (!admin) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message: 'Admin privileges required' },
         },
         403
@@ -344,13 +312,7 @@ export function createAdminRoutes() {
     const listFn = internal.api.v1.internal.admin.listAllEvents;
     const result = await ctx.runQuery(listFn, {});
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.events,
-      },
-      200
-    );
+    return c.json(result.events, 200);
   });
 
   // DELETE /admin/events/:eventId - Delete event
@@ -365,16 +327,8 @@ export function createAdminRoutes() {
       params: EventIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Event deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
+      204: {
+        description: 'Event deleted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -412,7 +366,6 @@ export function createAdminRoutes() {
     if (!admin) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message: 'Admin privileges required' },
         },
         403
@@ -426,19 +379,12 @@ export function createAdminRoutes() {
       const deleteFn = internal.api.v1.internal.events.deleteEvent;
       await ctx.runMutation(deleteFn, { eventId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Event deleted successfully' },
-        },
-        200
-      );
+      return c.body(null, 204);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to delete event';
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message },
         },
         404
@@ -490,7 +436,6 @@ export function createAdminRoutes() {
     if (!admin) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'FORBIDDEN', message: 'Admin privileges required' },
         },
         403
@@ -502,13 +447,7 @@ export function createAdminRoutes() {
     const listFn = internal.api.v1.internal.admin.listReportsAdmin;
     const result = await ctx.runQuery(listFn, {});
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.reports,
-      },
-      200
-    );
+    return c.json(result.reports, 200);
   });
 
   return app;

--- a/convex/api/v1/routes/availability.ts
+++ b/convex/api/v1/routes/availability.ts
@@ -72,12 +72,9 @@ export function createAvailabilityRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          eventId,
-          potentialDates: result.potentialDates,
-          userMembershipId: membership.membershipId,
-        },
+        eventId,
+        potentialDates: result.potentialDates,
+        userMembershipId: membership.membershipId,
       },
       200
     );
@@ -155,11 +152,8 @@ export function createAvailabilityRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          updated: result.updated,
-          created: result.created,
-        },
+        updated: result.updated,
+        created: result.created,
       },
       200
     );
@@ -216,13 +210,7 @@ export function createAvailabilityRoutes() {
     const getDatesFn = internal.api.v1.internal.availability.getPotentialDates;
     const result = await ctx.runQuery(getDatesFn, { eventId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.potentialDates,
-      },
-      200
-    );
+    return c.json(result.potentialDates, 200);
   });
 
   return app;

--- a/convex/api/v1/routes/events.ts
+++ b/convex/api/v1/routes/events.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { requireEventMembership, requireEventRole } from '../middleware/auth';
@@ -61,13 +60,7 @@ export function createEventRoutes() {
     const listFn = internal.api.v1.internal.events.listUserEvents;
     const result = await ctx.runQuery(listFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.events,
-      },
-      200
-    );
+    return c.json(result.events, 200);
   });
 
   // POST /events - Create event
@@ -123,7 +116,6 @@ export function createEventRoutes() {
     if (body.gdl && body.potentialDateTimeOptions) {
       return c.json(
         {
-          success: false as const,
           error: {
             code: 'VALIDATION_ERROR',
             message:
@@ -141,7 +133,6 @@ export function createEventRoutes() {
       if (!gdlResult.success) {
         return c.json(
           {
-            success: false as const,
             error: {
               code: 'GDL_PARSE_ERROR',
               message: `Invalid GDL expression: ${gdlResult.error}`,
@@ -168,11 +159,8 @@ export function createEventRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          eventId: result.eventId,
-          membershipId: result.membershipId,
-        },
+        eventId: result.eventId,
+        membershipId: result.membershipId,
       },
       201
     );
@@ -241,20 +229,13 @@ export function createEventRoutes() {
     if (!result) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message: 'Event not found' },
         },
         404
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // PATCH /events/:eventId - Update event
@@ -325,13 +306,7 @@ export function createEventRoutes() {
     const updateFn = internal.api.v1.internal.events.updateEvent;
     const result = await ctx.runMutation(updateFn, { eventId, ...body });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // DELETE /events/:eventId - Delete event
@@ -346,16 +321,8 @@ export function createEventRoutes() {
       params: EventIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Event deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
+      204: {
+        description: 'Event deleted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -397,13 +364,7 @@ export function createEventRoutes() {
     const deleteFn = internal.api.v1.internal.events.deleteEvent;
     await ctx.runMutation(deleteFn, { eventId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Event deleted successfully' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   return app;

--- a/convex/api/v1/routes/friends.ts
+++ b/convex/api/v1/routes/friends.ts
@@ -1,14 +1,13 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
-import { ErrorResponseSchema } from '../schemas/common';
+import { ErrorResponseSchema, MessageResponseSchema } from '../schemas/common';
 import {
   FriendListResponseSchema,
   FriendRequestListResponseSchema,
   UserSearchResponseSchema,
   SendFriendRequestSchema,
   FriendRequestResponseSchema,
-  FriendActionResponseSchema,
   FriendshipStatusResponseSchema,
   FriendshipIdParamSchema,
   SearchQuerySchema,
@@ -61,13 +60,7 @@ export function createFriendRoutes() {
     const listFn = internal.api.v1.internal.friends.listFriends;
     const result = await ctx.runQuery(listFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /friends/requests/incoming - List incoming friend requests
@@ -107,13 +100,7 @@ export function createFriendRoutes() {
     const listFn = internal.api.v1.internal.friends.listPendingRequests;
     const result = await ctx.runQuery(listFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /friends/requests/outgoing - List sent friend requests
@@ -153,13 +140,7 @@ export function createFriendRoutes() {
     const listFn = internal.api.v1.internal.friends.listSentRequests;
     const result = await ctx.runQuery(listFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /friends/search - Search users to add as friends
@@ -203,13 +184,7 @@ export function createFriendRoutes() {
     const searchFn = internal.api.v1.internal.friends.searchUsers;
     const result = await ctx.runQuery(searchFn, { personId, searchTerm: q });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /friends/status/:personId - Get friendship status with a user
@@ -255,13 +230,7 @@ export function createFriendRoutes() {
     const statusFn = internal.api.v1.internal.friends.getFriendshipStatus;
     const result = await ctx.runQuery(statusFn, { personId, targetPersonId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // POST /friends/requests - Send friend request
@@ -322,13 +291,7 @@ export function createFriendRoutes() {
       addresseeId: body.personId,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // POST /friends/requests/:friendshipId/accept - Accept friend request
@@ -347,7 +310,7 @@ export function createFriendRoutes() {
         description: 'Friend request accepted',
         content: {
           'application/json': {
-            schema: FriendActionResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -388,13 +351,7 @@ export function createFriendRoutes() {
     const acceptFn = internal.api.v1.internal.friends.acceptFriendRequest;
     await ctx.runMutation(acceptFn, { friendshipId, personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Friend request accepted' },
-      },
-      200
-    );
+    return c.json({ message: 'Friend request accepted' }, 200);
   });
 
   // POST /friends/requests/:friendshipId/decline - Decline friend request
@@ -413,7 +370,7 @@ export function createFriendRoutes() {
         description: 'Friend request declined',
         content: {
           'application/json': {
-            schema: FriendActionResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -454,13 +411,7 @@ export function createFriendRoutes() {
     const declineFn = internal.api.v1.internal.friends.declineFriendRequest;
     await ctx.runMutation(declineFn, { friendshipId, personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Friend request declined' },
-      },
-      200
-    );
+    return c.json({ message: 'Friend request declined' }, 200);
   });
 
   // DELETE /friends/requests/:friendshipId - Cancel friend request
@@ -475,13 +426,8 @@ export function createFriendRoutes() {
       params: FriendshipIdParamSchema,
     },
     responses: {
-      200: {
+      204: {
         description: 'Friend request cancelled',
-        content: {
-          'application/json': {
-            schema: FriendActionResponseSchema,
-          },
-        },
       },
       400: {
         description: 'Bad request',
@@ -520,13 +466,7 @@ export function createFriendRoutes() {
     const cancelFn = internal.api.v1.internal.friends.cancelFriendRequest;
     await ctx.runMutation(cancelFn, { friendshipId, personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Friend request cancelled' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   // DELETE /friends/:friendshipId - Remove friend
@@ -541,13 +481,8 @@ export function createFriendRoutes() {
       params: FriendshipIdParamSchema,
     },
     responses: {
-      200: {
+      204: {
         description: 'Friend removed',
-        content: {
-          'application/json': {
-            schema: FriendActionResponseSchema,
-          },
-        },
       },
       400: {
         description: 'Bad request',
@@ -586,13 +521,7 @@ export function createFriendRoutes() {
     const removeFn = internal.api.v1.internal.friends.removeFriend;
     await ctx.runMutation(removeFn, { friendshipId, personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Friend removed' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   return app;

--- a/convex/api/v1/routes/invites.ts
+++ b/convex/api/v1/routes/invites.ts
@@ -75,13 +75,7 @@ export function createInviteRoutes() {
     const listFn = internal.api.v1.internal.invites.listEventInvites;
     const result = await ctx.runQuery(listFn, { eventId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.invites,
-      },
-      200
-    );
+    return c.json(result.invites, 200);
   });
 
   // POST /events/:eventId/invites - Create invite
@@ -108,11 +102,8 @@ export function createInviteRoutes() {
         content: {
           'application/json': {
             schema: z.object({
-              success: z.literal(true),
-              data: z.object({
-                id: z.string(),
-                token: z.string(),
-              }),
+              id: z.string(),
+              token: z.string(),
             }),
           },
         },
@@ -162,11 +153,8 @@ export function createInviteRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          id: result.id,
-          token: result.token,
-        },
+        id: result.id,
+        token: result.token,
       },
       201
     );
@@ -184,16 +172,8 @@ export function createInviteRoutes() {
       params: InviteIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Invite deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
+      204: {
+        description: 'Invite deleted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -225,19 +205,12 @@ export function createInviteRoutes() {
       const deleteFn = internal.api.v1.internal.invites.deleteInvite;
       await ctx.runMutation(deleteFn, { inviteId, personId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Invite deleted successfully' },
-        },
-        200
-      );
+      return c.body(null, 204);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to delete invite';
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message },
         },
         404
@@ -287,20 +260,13 @@ export function createInviteRoutes() {
     if (!result) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message: 'Invite not found' },
         },
         404
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // POST /invites/:token/accept - Accept invite
@@ -364,11 +330,8 @@ export function createInviteRoutes() {
 
       return c.json(
         {
-          success: true as const,
-          data: {
-            eventId: result.eventId,
-            membershipId: result.membershipId,
-          },
+          eventId: result.eventId,
+          membershipId: result.membershipId,
         },
         200
       );
@@ -379,7 +342,6 @@ export function createInviteRoutes() {
       if (message === 'Invite not found') {
         return c.json(
           {
-            success: false as const,
             error: { code: 'NOT_FOUND', message },
           },
           404
@@ -388,7 +350,6 @@ export function createInviteRoutes() {
 
       return c.json(
         {
-          success: false as const,
           error: { code: 'BAD_REQUEST', message },
         },
         400

--- a/convex/api/v1/routes/members.ts
+++ b/convex/api/v1/routes/members.ts
@@ -3,13 +3,15 @@ import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { requireEventMembership, requireEventRole } from '../middleware/auth';
-import { ErrorResponseSchema, EventIdParamSchema } from '../schemas/common';
+import {
+  ErrorResponseSchema,
+  EventIdParamSchema,
+  MessageResponseSchema,
+} from '../schemas/common';
 import {
   MemberListResponseSchema,
-  MemberUpdateResponseSchema,
+  MemberDetailSchema,
   RsvpUpdateResponseSchema,
-  LeaveEventResponseSchema,
-  RemoveMemberResponseSchema,
   UpdateMemberRoleRequestSchema,
   UpdateRsvpRequestSchema,
 } from '../schemas/members';
@@ -74,13 +76,7 @@ export function createMemberRoutes() {
     const listFn = internal.api.v1.internal.members.listEventMembers;
     const result = await ctx.runQuery(listFn, { eventId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.members,
-      },
-      200
-    );
+    return c.json(result.members, 200);
   });
 
   // PATCH /events/:eventId/members/:memberId - Update member role
@@ -109,7 +105,7 @@ export function createMemberRoutes() {
         description: 'Member role updated',
         content: {
           'application/json': {
-            schema: MemberUpdateResponseSchema,
+            schema: MemberDetailSchema,
           },
         },
       },
@@ -156,13 +152,7 @@ export function createMemberRoutes() {
       newRole: body.role,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // DELETE /events/:eventId/members/:memberId - Remove member
@@ -181,13 +171,8 @@ export function createMemberRoutes() {
       }),
     },
     responses: {
-      200: {
-        description: 'Member removed',
-        content: {
-          'application/json': {
-            schema: RemoveMemberResponseSchema,
-          },
-        },
+      204: {
+        description: 'Member removed successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -228,13 +213,7 @@ export function createMemberRoutes() {
     const removeFn = internal.api.v1.internal.members.removeMember;
     await ctx.runMutation(removeFn, { membershipId: memberId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Member removed successfully' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   // POST /events/:eventId/leave - Leave event
@@ -253,7 +232,7 @@ export function createMemberRoutes() {
         description: 'Left event successfully',
         content: {
           'application/json': {
-            schema: LeaveEventResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -286,13 +265,7 @@ export function createMemberRoutes() {
     const leaveFn = internal.api.v1.internal.members.leaveEvent;
     await ctx.runMutation(leaveFn, { eventId, personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Left event successfully' },
-      },
-      200
-    );
+    return c.json({ message: 'Left event successfully' }, 200);
   });
 
   // PATCH /events/:eventId/rsvp - Update RSVP
@@ -358,11 +331,8 @@ export function createMemberRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          membershipId: result.membershipId,
-          rsvpStatus: result.rsvpStatus,
-        },
+        membershipId: result.membershipId,
+        rsvpStatus: result.rsvpStatus,
       },
       200
     );

--- a/convex/api/v1/routes/muting.ts
+++ b/convex/api/v1/routes/muting.ts
@@ -10,12 +10,10 @@ import { internal } from '../../../_generated/api';
 import {
   ErrorResponseSchema,
   EventIdParamSchema,
+  MessageResponseSchema,
   PostIdParamSchema,
 } from '../schemas/common';
-import {
-  MutedListResponseSchema,
-  MutingSuccessResponseSchema,
-} from '../schemas/muting';
+import { MutedListResponseSchema } from '../schemas/muting';
 
 type Variables = {
   ctx: ActionCtx;
@@ -75,11 +73,8 @@ export function createMutingRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          events: result.events,
-          posts: result.posts,
-        },
+        events: result.events,
+        posts: result.posts,
       },
       200
     );
@@ -102,7 +97,7 @@ export function createMutingRoutes() {
         description: 'Event muted',
         content: {
           'application/json': {
-            schema: MutingSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -148,13 +143,7 @@ export function createMutingRoutes() {
         ? 'Event was already muted'
         : 'Event muted successfully';
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message },
-        },
-        200
-      );
+      return c.json({ message }, 200);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to mute event';
@@ -163,7 +152,6 @@ export function createMutingRoutes() {
 
       return c.json(
         {
-          success: false as const,
           error: { code, message },
         },
         status
@@ -183,13 +171,8 @@ export function createMutingRoutes() {
       params: EventIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Event unmuted',
-        content: {
-          'application/json': {
-            schema: MutingSuccessResponseSchema,
-          },
-        },
+      204: {
+        description: 'Event unmuted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -221,19 +204,12 @@ export function createMutingRoutes() {
       const unmuteFn = internal.api.v1.internal.muting.unmuteEvent;
       await ctx.runMutation(unmuteFn, { personId, eventId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Event unmuted successfully' },
-        },
-        200
-      );
+      return c.body(null, 204);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Event is not muted';
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message },
         },
         404
@@ -258,7 +234,7 @@ export function createMutingRoutes() {
         description: 'Post muted',
         content: {
           'application/json': {
-            schema: MutingSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -304,13 +280,7 @@ export function createMutingRoutes() {
         ? 'Post was already muted'
         : 'Post muted successfully';
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message },
-        },
-        200
-      );
+      return c.json({ message }, 200);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to mute post';
@@ -319,7 +289,6 @@ export function createMutingRoutes() {
 
       return c.json(
         {
-          success: false as const,
           error: { code, message },
         },
         status
@@ -339,13 +308,8 @@ export function createMutingRoutes() {
       params: PostIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Post unmuted',
-        content: {
-          'application/json': {
-            schema: MutingSuccessResponseSchema,
-          },
-        },
+      204: {
+        description: 'Post unmuted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -377,19 +341,12 @@ export function createMutingRoutes() {
       const unmuteFn = internal.api.v1.internal.muting.unmutePost;
       await ctx.runMutation(unmuteFn, { personId, postId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Post unmuted successfully' },
-        },
-        200
-      );
+      return c.body(null, 204);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Post is not muted';
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message },
         },
         404

--- a/convex/api/v1/routes/notifications.ts
+++ b/convex/api/v1/routes/notifications.ts
@@ -7,12 +7,11 @@ import {
 extendZodWithOpenApi(z);
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
-import { ErrorResponseSchema } from '../schemas/common';
+import { ErrorResponseSchema, MessageResponseSchema } from '../schemas/common';
 import {
   NotificationIdParamSchema,
   NotificationListResponseSchema,
   UnreadCountResponseSchema,
-  NotificationSuccessResponseSchema,
 } from '../schemas/notifications';
 
 type Variables = {
@@ -73,13 +72,7 @@ export function createNotificationRoutes() {
     const listFn = internal.api.v1.internal.notifications.listNotifications;
     const result = await ctx.runQuery(listFn, { personId, unreadOnly });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /notifications/count - Get unread count
@@ -119,13 +112,7 @@ export function createNotificationRoutes() {
     const countFn = internal.api.v1.internal.notifications.getUnreadCount;
     const result = await ctx.runQuery(countFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { count: result.count },
-      },
-      200
-    );
+    return c.json({ count: result.count }, 200);
   });
 
   // POST /notifications/:notificationId/read - Mark as read
@@ -144,7 +131,7 @@ export function createNotificationRoutes() {
         description: 'Notification marked as read',
         content: {
           'application/json': {
-            schema: NotificationSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -178,23 +165,11 @@ export function createNotificationRoutes() {
       const readFn = internal.api.v1.internal.notifications.markAsRead;
       await ctx.runMutation(readFn, { notificationId, personId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Notification marked as read' },
-        },
-        200
-      );
+      return c.json({ message: 'Notification marked as read' }, 200);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Notification not found';
-      return c.json(
-        {
-          success: false as const,
-          error: { code: 'NOT_FOUND', message },
-        },
-        404
-      );
+      return c.json({ error: { code: 'NOT_FOUND', message } }, 404);
     }
   });
 
@@ -214,7 +189,7 @@ export function createNotificationRoutes() {
         description: 'Notification marked as unread',
         content: {
           'application/json': {
-            schema: NotificationSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -248,23 +223,11 @@ export function createNotificationRoutes() {
       const unreadFn = internal.api.v1.internal.notifications.markAsUnread;
       await ctx.runMutation(unreadFn, { notificationId, personId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Notification marked as unread' },
-        },
-        200
-      );
+      return c.json({ message: 'Notification marked as unread' }, 200);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Notification not found';
-      return c.json(
-        {
-          success: false as const,
-          error: { code: 'NOT_FOUND', message },
-        },
-        404
-      );
+      return c.json({ error: { code: 'NOT_FOUND', message } }, 404);
     }
   });
 
@@ -281,7 +244,7 @@ export function createNotificationRoutes() {
         description: 'All notifications marked as read',
         content: {
           'application/json': {
-            schema: NotificationSuccessResponseSchema,
+            schema: MessageResponseSchema,
           },
         },
       },
@@ -306,12 +269,7 @@ export function createNotificationRoutes() {
     const result = await ctx.runMutation(markAllFn, { personId });
 
     return c.json(
-      {
-        success: true as const,
-        data: {
-          message: `Marked ${result.count} notifications as read`,
-        },
-      },
+      { message: `Marked ${result.count} notifications as read` },
       200
     );
   });
@@ -328,13 +286,8 @@ export function createNotificationRoutes() {
       params: NotificationIdParamSchema,
     },
     responses: {
-      200: {
+      204: {
         description: 'Notification deleted',
-        content: {
-          'application/json': {
-            schema: NotificationSuccessResponseSchema,
-          },
-        },
       },
       401: {
         description: 'Unauthorized',
@@ -367,23 +320,11 @@ export function createNotificationRoutes() {
       const deleteFn = internal.api.v1.internal.notifications.deleteNotification;
       await ctx.runMutation(deleteFn, { notificationId, personId });
 
-      return c.json(
-        {
-          success: true as const,
-          data: { message: 'Notification deleted' },
-        },
-        200
-      );
+      return c.body(null, 204);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Notification not found';
-      return c.json(
-        {
-          success: false as const,
-          error: { code: 'NOT_FOUND', message },
-        },
-        404
-      );
+      return c.json({ error: { code: 'NOT_FOUND', message } }, 404);
     }
   });
 
@@ -396,13 +337,8 @@ export function createNotificationRoutes() {
     description: 'Delete all notifications for the authenticated user',
     security: [{ apiKey: [] }],
     responses: {
-      200: {
+      204: {
         description: 'All notifications deleted',
-        content: {
-          'application/json': {
-            schema: NotificationSuccessResponseSchema,
-          },
-        },
       },
       401: {
         description: 'Unauthorized',
@@ -423,17 +359,9 @@ export function createNotificationRoutes() {
     // @ts-ignore - Type instantiation is excessively deep (TS2589)
     // prettier-ignore
     const deleteAllFn = internal.api.v1.internal.notifications.deleteAllNotifications;
-    const result = await ctx.runMutation(deleteAllFn, { personId });
+    await ctx.runMutation(deleteAllFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: {
-          message: `Deleted ${result.count} notifications`,
-        },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   return app;

--- a/convex/api/v1/routes/posts.ts
+++ b/convex/api/v1/routes/posts.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { requireEventMembership, canModifyPost } from '../middleware/auth';
@@ -77,13 +76,7 @@ export function createPostRoutes() {
     const listFn = internal.api.v1.internal.posts.listEventPosts;
     const result = await ctx.runQuery(listFn, { eventId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.posts,
-      },
-      200
-    );
+    return c.json(result.posts, 200);
   });
 
   // POST /events/:eventId/posts - Create post
@@ -158,15 +151,7 @@ export function createPostRoutes() {
       ...body,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: {
-          postId: result.postId,
-        },
-      },
-      201
-    );
+    return c.json({ postId: result.postId }, 201);
   });
 
   // GET /posts/:postId - Get post details
@@ -228,21 +213,12 @@ export function createPostRoutes() {
 
     if (!result) {
       return c.json(
-        {
-          success: false as const,
-          error: { code: 'NOT_FOUND', message: 'Post not found' },
-        },
+        { error: { code: 'NOT_FOUND', message: 'Post not found' } },
         404
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // PATCH /posts/:postId - Update post
@@ -317,13 +293,7 @@ export function createPostRoutes() {
     const updateFn = internal.api.v1.internal.posts.updatePost;
     const result = await ctx.runMutation(updateFn, { postId, ...body });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // DELETE /posts/:postId - Delete post
@@ -338,16 +308,8 @@ export function createPostRoutes() {
       params: PostIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Post deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
+      204: {
+        description: 'Post deleted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -393,13 +355,7 @@ export function createPostRoutes() {
     const deleteFn = internal.api.v1.internal.posts.deletePost;
     await ctx.runMutation(deleteFn, { postId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Post deleted successfully' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   return app;

--- a/convex/api/v1/routes/profile.ts
+++ b/convex/api/v1/routes/profile.ts
@@ -3,7 +3,7 @@ import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { ErrorResponseSchema } from '../schemas/common';
 import {
-  ProfileResponseSchema,
+  ProfileSchema,
   UpdateProfileRequestSchema,
   UsernameParamSchema,
 } from '../schemas/profile';
@@ -31,7 +31,7 @@ export function createProfileRoutes() {
         description: 'User profile',
         content: {
           'application/json': {
-            schema: ProfileResponseSchema,
+            schema: ProfileSchema,
           },
         },
       },
@@ -66,20 +66,13 @@ export function createProfileRoutes() {
     if (!result) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message: 'Profile not found' },
         },
         404
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /profile/:username - Get profile by username
@@ -98,7 +91,7 @@ export function createProfileRoutes() {
         description: 'User profile',
         content: {
           'application/json': {
-            schema: ProfileResponseSchema,
+            schema: ProfileSchema,
           },
         },
       },
@@ -133,20 +126,13 @@ export function createProfileRoutes() {
     if (!result) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message: 'User not found' },
         },
         404
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // PUT /profile - Update current user's profile
@@ -171,7 +157,7 @@ export function createProfileRoutes() {
         description: 'Updated profile',
         content: {
           'application/json': {
-            schema: ProfileResponseSchema,
+            schema: ProfileSchema,
           },
         },
       },
@@ -209,13 +195,7 @@ export function createProfileRoutes() {
       ...body,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   return app;

--- a/convex/api/v1/routes/replies.ts
+++ b/convex/api/v1/routes/replies.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { canModifyReply } from '../middleware/auth';
@@ -86,20 +85,13 @@ export function createReplyRoutes() {
     if (!result) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message: 'Post not found' },
         },
         404
       );
     }
 
-    return c.json(
-      {
-        success: true as const,
-        data: result.replies,
-      },
-      200
-    );
+    return c.json(result.replies, 200);
   });
 
   // POST /posts/:postId/replies - Create reply
@@ -182,7 +174,6 @@ export function createReplyRoutes() {
     if (!result) {
       return c.json(
         {
-          success: false as const,
           error: { code: 'NOT_FOUND', message: 'Post not found' },
         },
         404
@@ -191,10 +182,7 @@ export function createReplyRoutes() {
 
     return c.json(
       {
-        success: true as const,
-        data: {
-          replyId: result.replyId,
-        },
+        replyId: result.replyId,
       },
       201
     );
@@ -272,13 +260,7 @@ export function createReplyRoutes() {
     const updateFn = internal.api.v1.internal.replies.updateReply;
     const result = await ctx.runMutation(updateFn, { replyId, ...body });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // DELETE /replies/:replyId - Delete reply
@@ -293,16 +275,8 @@ export function createReplyRoutes() {
       params: ReplyIdParamSchema,
     },
     responses: {
-      200: {
+      204: {
         description: 'Reply deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
       },
       401: {
         description: 'Unauthorized',
@@ -348,13 +322,7 @@ export function createReplyRoutes() {
     const deleteFn = internal.api.v1.internal.replies.deleteReply;
     await ctx.runMutation(deleteFn, { replyId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Reply deleted successfully' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   return app;

--- a/convex/api/v1/routes/reports.ts
+++ b/convex/api/v1/routes/reports.ts
@@ -81,10 +81,7 @@ export function createReportRoutes() {
 
       return c.json(
         {
-          success: true as const,
-          data: {
-            reportId: result.reportId,
-          },
+          reportId: result.reportId,
         },
         201
       );
@@ -93,7 +90,6 @@ export function createReportRoutes() {
         error instanceof Error ? error.message : 'Failed to create report';
       return c.json(
         {
-          success: false as const,
           error: { code: 'BAD_REQUEST', message },
         },
         400

--- a/convex/api/v1/routes/settings.ts
+++ b/convex/api/v1/routes/settings.ts
@@ -3,9 +3,9 @@ import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { ErrorResponseSchema } from '../schemas/common';
 import {
-  PrivacySettingsResponseSchema,
+  PrivacySettingsSchema,
   UpdatePrivacySettingsRequestSchema,
-  NotificationSettingsResponseSchema,
+  NotificationSettingsSchema,
 } from '../schemas/settings';
 
 // Type for Hono app with Convex context
@@ -31,7 +31,7 @@ export function createSettingsRoutes() {
         description: 'Privacy settings',
         content: {
           'application/json': {
-            schema: PrivacySettingsResponseSchema,
+            schema: PrivacySettingsSchema,
           },
         },
       },
@@ -55,13 +55,7 @@ export function createSettingsRoutes() {
     const getFn = internal.api.v1.internal.settings.getPrivacySettings;
     const result = await ctx.runQuery(getFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // PUT /settings/privacy - Update privacy settings
@@ -86,7 +80,7 @@ export function createSettingsRoutes() {
         description: 'Updated privacy settings',
         content: {
           'application/json': {
-            schema: PrivacySettingsResponseSchema,
+            schema: PrivacySettingsSchema,
           },
         },
       },
@@ -119,13 +113,7 @@ export function createSettingsRoutes() {
     const updateFn = internal.api.v1.internal.settings.updatePrivacySettings;
     const result = await ctx.runMutation(updateFn, { personId, ...body });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /settings/notifications - Get notification settings
@@ -142,7 +130,7 @@ export function createSettingsRoutes() {
         description: 'Notification settings',
         content: {
           'application/json': {
-            schema: NotificationSettingsResponseSchema,
+            schema: NotificationSettingsSchema,
           },
         },
       },
@@ -166,13 +154,7 @@ export function createSettingsRoutes() {
     const getFn = internal.api.v1.internal.settings.getNotificationSettings;
     const result = await ctx.runQuery(getFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   return app;

--- a/convex/api/v1/routes/themes.ts
+++ b/convex/api/v1/routes/themes.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { z } from '@hono/zod-openapi';
 import type { ActionCtx } from '../../../_generated/server';
 import { internal } from '../../../_generated/api';
 import { ErrorResponseSchema } from '../schemas/common';
@@ -60,13 +59,7 @@ export function createThemeRoutes() {
     const listFn = internal.api.v1.internal.themes.listCustomThemes;
     const result = await ctx.runQuery(listFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // GET /themes/preferences - Get theme preferences
@@ -106,13 +99,7 @@ export function createThemeRoutes() {
     const getFn = internal.api.v1.internal.themes.getThemePreferences;
     const result = await ctx.runQuery(getFn, { personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // POST /themes - Create custom theme
@@ -174,13 +161,7 @@ export function createThemeRoutes() {
       tokenOverrides: body.tokenOverrides ?? undefined,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      201
-    );
+    return c.json(result, 201);
   });
 
   // PUT /themes/:themeId - Update custom theme
@@ -260,13 +241,7 @@ export function createThemeRoutes() {
       ...body,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   // DELETE /themes/:themeId - Delete custom theme
@@ -281,16 +256,8 @@ export function createThemeRoutes() {
       params: ThemeIdParamSchema,
     },
     responses: {
-      200: {
-        description: 'Theme deleted',
-        content: {
-          'application/json': {
-            schema: z.object({
-              success: z.literal(true),
-              data: z.object({ message: z.string() }),
-            }),
-          },
-        },
+      204: {
+        description: 'Deleted successfully',
       },
       401: {
         description: 'Unauthorized',
@@ -329,13 +296,7 @@ export function createThemeRoutes() {
     const deleteFn = internal.api.v1.internal.themes.deleteCustomTheme;
     await ctx.runMutation(deleteFn, { themeId, personId });
 
-    return c.json(
-      {
-        success: true as const,
-        data: { message: 'Theme deleted successfully' },
-      },
-      200
-    );
+    return c.body(null, 204);
   });
 
   // PUT /themes/preferences - Set theme preference
@@ -398,13 +359,7 @@ export function createThemeRoutes() {
       selectedCustomThemeId: body.selectedCustomThemeId ?? undefined,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        data: result,
-      },
-      200
-    );
+    return c.json(result, 200);
   });
 
   return app;

--- a/convex/api/v1/schemas/addons.ts
+++ b/convex/api/v1/schemas/addons.ts
@@ -102,19 +102,8 @@ export const AddonConfigResponseSchema = z
 
 // Addon list response
 export const AddonListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(AddonConfigResponseSchema),
-  })
+  .array(AddonConfigResponseSchema)
   .openapi('AddonListResponse');
-
-// Single addon config response
-export const AddonConfigSingleResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: AddonConfigResponseSchema,
-  })
-  .openapi('AddonConfigResponse');
 
 // Addon data entry response object
 export const AddonDataEntrySchema = z
@@ -130,24 +119,5 @@ export const AddonDataEntrySchema = z
 
 // Addon data list response
 export const AddonDataListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(AddonDataEntrySchema),
-  })
+  .array(AddonDataEntrySchema)
   .openapi('AddonDataListResponse');
-
-// Addon data single response
-export const AddonDataSingleResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: AddonDataEntrySchema,
-  })
-  .openapi('AddonDataResponse');
-
-// Success message response (for enable/disable/delete)
-export const AddonSuccessResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.object({ message: z.string() }),
-  })
-  .openapi('AddonSuccessResponse');

--- a/convex/api/v1/schemas/admin.ts
+++ b/convex/api/v1/schemas/admin.ts
@@ -58,24 +58,15 @@ export const UserIdParamSchema = z.object({
 
 // Admin user list response
 export const AdminUserListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(AdminUserSummarySchema),
-  })
+  .array(AdminUserSummarySchema)
   .openapi('AdminUserListResponse');
 
 // Admin event list response
 export const AdminEventListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(AdminEventSummarySchema),
-  })
+  .array(AdminEventSummarySchema)
   .openapi('AdminEventListResponse');
 
 // Admin report list response
 export const AdminReportListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(ReportSummarySchema),
-  })
+  .array(ReportSummarySchema)
   .openapi('AdminReportListResponse');

--- a/convex/api/v1/schemas/availability.ts
+++ b/convex/api/v1/schemas/availability.ts
@@ -51,12 +51,9 @@ export const AvailabilityGridEntrySchema = z
 // Full availability grid response
 export const AvailabilityGridResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      eventId: z.string(),
-      potentialDates: z.array(AvailabilityGridEntrySchema),
-      userMembershipId: z.string(),
-    }),
+    eventId: z.string(),
+    potentialDates: z.array(AvailabilityGridEntrySchema),
+    userMembershipId: z.string(),
   })
   .openapi('AvailabilityGridResponse');
 
@@ -75,18 +72,12 @@ export const SubmitAvailabilityRequestSchema = z
 // Submit availability response
 export const SubmitAvailabilityResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      updated: z.number().int(),
-      created: z.number().int(),
-    }),
+    updated: z.number().int(),
+    created: z.number().int(),
   })
   .openapi('SubmitAvailabilityResponse');
 
 // Potential dates list response
 export const PotentialDatesResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(PotentialDateTimeSchema),
-  })
+  .array(PotentialDateTimeSchema)
   .openapi('PotentialDatesResponse');

--- a/convex/api/v1/schemas/common.ts
+++ b/convex/api/v1/schemas/common.ts
@@ -11,7 +11,6 @@ extendZodWithOpenApi(z);
 // Error response schema
 export const ErrorResponseSchema = z
   .object({
-    success: z.literal(false),
     error: z.object({
       code: z.string().openapi({ example: 'NOT_FOUND' }),
       message: z.string().openapi({ example: 'Resource not found' }),
@@ -19,12 +18,14 @@ export const ErrorResponseSchema = z
   })
   .openapi('ErrorResponse');
 
-// Success response wrapper (generic)
-export const SuccessResponseSchema = z
+// Simple message response (for actions like mark-as-read, accept, etc.)
+export const MessageResponseSchema = z
   .object({
-    success: z.literal(true),
+    message: z
+      .string()
+      .openapi({ example: 'Operation completed successfully' }),
   })
-  .openapi('SuccessResponse');
+  .openapi('MessageResponse');
 
 // Pagination query parameters
 export const PaginationQuerySchema = z.object({
@@ -42,7 +43,6 @@ export const PaginatedResponseSchema = <T extends z.ZodTypeAny>(
   itemSchema: T
 ) =>
   z.object({
-    success: z.literal(true),
     data: z.array(itemSchema),
     pagination: z.object({
       hasMore: z.boolean(),

--- a/convex/api/v1/schemas/events.ts
+++ b/convex/api/v1/schemas/events.ts
@@ -117,27 +117,16 @@ export const UpdateEventRequestSchema = z
 
 // Event list response
 export const EventListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(EventSummarySchema),
-  })
+  .array(EventSummarySchema)
   .openapi('EventListResponse');
 
 // Single event response
-export const EventResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: EventDetailSchema,
-  })
-  .openapi('EventResponse');
+export const EventResponseSchema = EventDetailSchema;
 
 // Event create response
 export const EventCreateResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      eventId: z.string(),
-      membershipId: z.string(),
-    }),
+    eventId: z.string(),
+    membershipId: z.string(),
   })
   .openapi('EventCreateResponse');

--- a/convex/api/v1/schemas/friends.ts
+++ b/convex/api/v1/schemas/friends.ts
@@ -1,6 +1,6 @@
 import { z, extendZodWithOpenApi } from '@hono/zod-openapi';
 extendZodWithOpenApi(z);
-import { TimestampSchema } from './common';
+import { TimestampSchema, MessageResponseSchema } from './common';
 
 /**
  * Friends-related API schemas
@@ -62,26 +62,17 @@ export const UserSearchResultSchema = z
 
 // Friend list response
 export const FriendListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(FriendSummarySchema),
-  })
+  .array(FriendSummarySchema)
   .openapi('FriendListResponse');
 
 // Friend requests list response
 export const FriendRequestListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(FriendRequestSchema),
-  })
+  .array(FriendRequestSchema)
   .openapi('FriendRequestListResponse');
 
 // User search response
 export const UserSearchResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(UserSearchResultSchema),
-  })
+  .array(UserSearchResultSchema)
   .openapi('UserSearchResponse');
 
 // Send friend request request body
@@ -96,33 +87,20 @@ export const SendFriendRequestSchema = z
 // Friend request response
 export const FriendRequestResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      friendshipId: z.string(),
-      status: z.enum(['PENDING', 'ACCEPTED']),
-      message: z.string(),
-    }),
+    friendshipId: z.string(),
+    status: z.enum(['PENDING', 'ACCEPTED']),
+    message: z.string(),
   })
   .openapi('FriendRequestResponse');
 
 // Accept/decline/cancel request response
-export const FriendActionResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.object({
-      message: z.string(),
-    }),
-  })
-  .openapi('FriendActionResponse');
+export const FriendActionResponseSchema = MessageResponseSchema;
 
 // Friendship status response
 export const FriendshipStatusResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      status: FriendshipStatusSchema,
-      friendshipId: z.string().nullable(),
-    }),
+    status: FriendshipStatusSchema,
+    friendshipId: z.string().nullable(),
   })
   .openapi('FriendshipStatusResponse');
 

--- a/convex/api/v1/schemas/invites.ts
+++ b/convex/api/v1/schemas/invites.ts
@@ -70,35 +70,19 @@ export const InviteTokenParamSchema = z.object({
 
 // Invite list response
 export const InviteListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(InviteSummarySchema),
-  })
+  .array(InviteSummarySchema)
   .openapi('InviteListResponse');
 
 // Single invite response
-export const InviteResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: InviteSummarySchema,
-  })
-  .openapi('InviteResponse');
+export const InviteResponseSchema = InviteSummarySchema;
 
 // Public invite response
-export const InvitePublicResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: InvitePublicSchema,
-  })
-  .openapi('InvitePublicResponse');
+export const InvitePublicResponseSchema = InvitePublicSchema;
 
 // Accept invite response
 export const AcceptInviteResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      eventId: z.string(),
-      membershipId: z.string(),
-    }),
+    eventId: z.string(),
+    membershipId: z.string(),
   })
   .openapi('AcceptInviteResponse');

--- a/convex/api/v1/schemas/members.ts
+++ b/convex/api/v1/schemas/members.ts
@@ -25,10 +25,7 @@ export const MemberDetailSchema = z
 
 // Member list response
 export const MemberListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(MemberDetailSchema),
-  })
+  .array(MemberDetailSchema)
   .openapi('MemberListResponse');
 
 // Update member role request body
@@ -45,41 +42,10 @@ export const UpdateRsvpRequestSchema = z
   })
   .openapi('UpdateRsvpRequest');
 
-// Member role update response
-export const MemberUpdateResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: MemberDetailSchema,
-  })
-  .openapi('MemberUpdateResponse');
-
 // RSVP update response
 export const RsvpUpdateResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      membershipId: z.string(),
-      rsvpStatus: RsvpStatusSchema,
-    }),
+    membershipId: z.string(),
+    rsvpStatus: RsvpStatusSchema,
   })
   .openapi('RsvpUpdateResponse');
-
-// Leave event response
-export const LeaveEventResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.object({
-      message: z.string(),
-    }),
-  })
-  .openapi('LeaveEventResponse');
-
-// Remove member response
-export const RemoveMemberResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.object({
-      message: z.string(),
-    }),
-  })
-  .openapi('RemoveMemberResponse');

--- a/convex/api/v1/schemas/muting.ts
+++ b/convex/api/v1/schemas/muting.ts
@@ -41,20 +41,7 @@ export const MutedPostSchema = z
 // Muted list response (combined or filtered)
 export const MutedListResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      events: z.array(MutedEventSchema),
-      posts: z.array(MutedPostSchema),
-    }),
+    events: z.array(MutedEventSchema),
+    posts: z.array(MutedPostSchema),
   })
   .openapi('MutedListResponse');
-
-// Generic muting success response
-export const MutingSuccessResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.object({
-      message: z.string(),
-    }),
-  })
-  .openapi('MutingSuccessResponse');

--- a/convex/api/v1/schemas/notifications.ts
+++ b/convex/api/v1/schemas/notifications.ts
@@ -86,28 +86,12 @@ export const NotificationIdParamSchema = z.object({
 
 // Notification list response
 export const NotificationListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(NotificationSchema),
-  })
+  .array(NotificationSchema)
   .openapi('NotificationListResponse');
 
 // Unread count response
 export const UnreadCountResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      count: z.number().int(),
-    }),
+    count: z.number().int(),
   })
   .openapi('UnreadCountResponse');
-
-// Generic notification success response
-export const NotificationSuccessResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.object({
-      message: z.string(),
-    }),
-  })
-  .openapi('NotificationSuccessResponse');

--- a/convex/api/v1/schemas/posts.ts
+++ b/convex/api/v1/schemas/posts.ts
@@ -76,26 +76,15 @@ export const UpdatePostRequestSchema = z
 
 // Post list response
 export const PostListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(PostSummarySchema),
-  })
+  .array(PostSummarySchema)
   .openapi('PostListResponse');
 
 // Single post response
-export const PostResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: PostDetailSchema,
-  })
-  .openapi('PostResponse');
+export const PostResponseSchema = PostDetailSchema;
 
 // Post create response
 export const PostCreateResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      postId: z.string(),
-    }),
+    postId: z.string(),
   })
   .openapi('PostCreateResponse');

--- a/convex/api/v1/schemas/profile.ts
+++ b/convex/api/v1/schemas/profile.ts
@@ -49,11 +49,3 @@ export const UsernameParamSchema = z.object({
     description: 'Username to look up',
   }),
 });
-
-// Profile response
-export const ProfileResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: ProfileSchema,
-  })
-  .openapi('ProfileResponse');

--- a/convex/api/v1/schemas/replies.ts
+++ b/convex/api/v1/schemas/replies.ts
@@ -42,26 +42,15 @@ export const UpdateReplyRequestSchema = z
 
 // Reply list response
 export const ReplyListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(ReplyDetailSchema),
-  })
+  .array(ReplyDetailSchema)
   .openapi('ReplyListResponse');
 
-// Single reply response
-export const ReplyResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: ReplyDetailSchema,
-  })
-  .openapi('ReplyResponse');
+// Single reply response (alias for ReplyDetailSchema)
+export const ReplyResponseSchema = ReplyDetailSchema;
 
 // Reply create response
 export const ReplyCreateResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      replyId: z.string(),
-    }),
+    replyId: z.string(),
   })
   .openapi('ReplyCreateResponse');

--- a/convex/api/v1/schemas/reports.ts
+++ b/convex/api/v1/schemas/reports.ts
@@ -74,9 +74,6 @@ export const CreateReportRequestSchema = z
 // Report create response
 export const ReportCreateResponseSchema = z
   .object({
-    success: z.literal(true),
-    data: z.object({
-      reportId: z.string(),
-    }),
+    reportId: z.string(),
   })
   .openapi('ReportCreateResponse');

--- a/convex/api/v1/schemas/settings.ts
+++ b/convex/api/v1/schemas/settings.ts
@@ -70,19 +70,3 @@ export const NotificationSettingsSchema = z
     typeSettings: z.array(NotificationTypeSettingSchema),
   })
   .openapi('NotificationSettings');
-
-// Privacy settings response
-export const PrivacySettingsResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: PrivacySettingsSchema,
-  })
-  .openapi('PrivacySettingsResponse');
-
-// Notification settings response
-export const NotificationSettingsResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: NotificationSettingsSchema,
-  })
-  .openapi('NotificationSettingsResponse');

--- a/convex/api/v1/schemas/themes.ts
+++ b/convex/api/v1/schemas/themes.ts
@@ -159,22 +159,10 @@ export const SetThemePreferenceRequestSchema = z
 
 // Response schemas
 export const CustomThemeListResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: z.array(CustomThemeSchema),
-  })
+  .array(CustomThemeSchema)
   .openapi('CustomThemeListResponse');
 
-export const CustomThemeResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: CustomThemeSchema,
-  })
-  .openapi('CustomThemeResponse');
+export const CustomThemeResponseSchema = CustomThemeSchema;
 
-export const ThemePreferencesResponseSchema = z
-  .object({
-    success: z.literal(true),
-    data: ThemePreferencesSchema.nullable(),
-  })
-  .openapi('ThemePreferencesResponse');
+export const ThemePreferencesResponseSchema =
+  ThemePreferencesSchema.nullable().openapi('ThemePreferencesResponse');

--- a/packages/web/app/docs/api/page.tsx
+++ b/packages/web/app/docs/api/page.tsx
@@ -181,19 +181,16 @@ export default function APIReferencePage() {
             path='/events'
             summary='List events'
             description='Get all events the authenticated user is a member of.'
-            response={`{
-  "success": true,
-  "data": [{
-    "id": "k170...",
-    "title": "Team Offsite",
-    "description": "Annual event",
-    "location": "Mountain View",
-    "chosenDateTime": 1704067200000,
-    "memberCount": 12,
-    "userRole": "ORGANIZER",
-    "userRsvpStatus": "YES"
-  }]
-}`}
+            response={`[{
+  "id": "k170...",
+  "title": "Team Offsite",
+  "description": "Annual event",
+  "location": "Mountain View",
+  "chosenDateTime": 1704067200000,
+  "memberCount": 12,
+  "userRole": "ORGANIZER",
+  "userRsvpStatus": "YES"
+}]`}
             curl={`curl -H "x-api-key: grp_xxx" \\
   https://api.groupi.gg/api/v1/events`}
           />
@@ -229,11 +226,8 @@ export default function APIReferencePage() {
   "reminderOffset": "1_DAY"           // optional
 }`}
             response={`{
-  "success": true,
-  "data": {
-    "eventId": "k170...",
-    "membershipId": "k171..."
-  }
+  "eventId": "k170...",
+  "membershipId": "k171..."
 }`}
             curl={`curl -X POST -H "x-api-key: grp_xxx" \\
   -H "Content-Type: application/json" \\
@@ -246,19 +240,16 @@ export default function APIReferencePage() {
             summary='Get event details'
             description='Get full details of a specific event. Requires membership.'
             response={`{
-  "success": true,
-  "data": {
-    "id": "k170...",
-    "title": "Team Offsite",
-    "description": "...",
-    "location": "...",
-    "timezone": "America/New_York",
-    "chosenDateTime": null,
-    "reminderOffset": "1_DAY",
-    "creator": {
-      "id": "k172...",
-      "user": { "name": "Alice", "username": "alice" }
-    }
+  "id": "k170...",
+  "title": "Team Offsite",
+  "description": "...",
+  "location": "...",
+  "timezone": "America/New_York",
+  "chosenDateTime": null,
+  "reminderOffset": "1_DAY",
+  "creator": {
+    "id": "k172...",
+    "user": { "name": "Alice", "username": "alice" }
   }
 }`}
           />
@@ -298,10 +289,7 @@ export default function APIReferencePage() {
   "title": "Meeting Notes",   // required
   "content": "Discussed..."   // required
 }`}
-            response={`{
-  "success": true,
-  "data": { "postId": "k173..." }
-}`}
+            response={`{ "postId": "k173..." }`}
           />
           <Endpoint
             method='GET'
@@ -355,16 +343,13 @@ export default function APIReferencePage() {
             path='/events/{eventId}/members'
             summary='List members'
             description='Get all members of an event with their roles and RSVP status.'
-            response={`{
-  "success": true,
-  "data": [{
-    "id": "k174...",
-    "role": "ATTENDEE",
-    "rsvpStatus": "YES",
-    "person": { "id": "...", "userId": "..." },
-    "user": { "name": "Bob", "username": "bob" }
-  }]
-}`}
+            response={`[{
+  "id": "k174...",
+  "role": "ATTENDEE",
+  "rsvpStatus": "YES",
+  "person": { "id": "...", "userId": "..." },
+  "user": { "name": "Bob", "username": "bob" }
+}]`}
           />
           <Endpoint
             method='PATCH'
@@ -451,7 +436,7 @@ export default function APIReferencePage() {
             method='GET'
             path='/notifications/count'
             summary='Get unread count'
-            response={`{ "success": true, "data": { "count": 5 } }`}
+            response={`{ "count": 5 }`}
           />
           <Endpoint
             method='POST'
@@ -490,10 +475,7 @@ export default function APIReferencePage() {
             method='POST'
             path='/events/{eventId}/invites'
             summary='Create invite link'
-            response={`{
-  "success": true,
-  "data": { "inviteId": "...", "token": "abc123", "url": "https://groupi.gg/invite/abc123" }
-}`}
+            response={`{ "id": "...", "token": "abc123" }`}
           />
           <Endpoint
             method='DELETE'
@@ -650,15 +632,21 @@ export default function APIReferencePage() {
           <div className='rounded-card bg-card p-4 text-sm space-y-3'>
             <div>
               <p className='font-medium mb-1'>Success</p>
+              <p className='text-muted-foreground text-xs mb-1'>
+                Data is returned directly — no envelope. HTTP status code
+                indicates success (200, 201, 204).
+              </p>
               <pre className='bg-bg-sunken rounded-input p-3 text-xs'>
-                {`{ "success": true, "data": { ... } }`}
+                {`// GET /events/{eventId} → 200
+{ "id": "k170...", "title": "Team Offsite", ... }
+
+// DELETE /events/{eventId} → 204 No Content`}
               </pre>
             </div>
             <div>
               <p className='font-medium mb-1'>Error</p>
               <pre className='bg-bg-sunken rounded-input p-3 text-xs'>
                 {`{
-  "success": false,
   "error": {
     "code": "NOT_FOUND",
     "message": "Event not found"

--- a/packages/web/convex/_generated/api.js
+++ b/packages/web/convex/_generated/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Generated `api` utility.
  *

--- a/packages/web/convex/_generated/server.d.ts
+++ b/packages/web/convex/_generated/server.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
  *

--- a/packages/web/convex/_generated/server.js
+++ b/packages/web/convex/_generated/server.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
  *


### PR DESCRIPTION
## Summary

- **Remove `{ success, data }` envelope** from all REST API success responses — data is returned directly
- **Remove `success: false`** from error responses — errors now use `{ error: { code, message } }` only
- **Delete operations return `204 No Content`** instead of `200` with a message body
- **Action endpoints** (mark-as-read, leave, accept, etc.) return `{ message: "..." }` directly
- Updated API docs page, OpenAPI schemas, and addon rules to match

## Details

All 15 API domains refactored: events, posts, replies, members, availability, friends, addons, notifications, muting, profile, settings, themes, invites, reports, admin.

**Before:**
```json
{ "success": true, "data": { "id": "k170...", "title": "Team Offsite" } }
{ "success": false, "error": { "code": "NOT_FOUND", "message": "Event not found" } }
```

**After:**
```json
{ "id": "k170...", "title": "Team Offsite" }
{ "error": { "code": "NOT_FOUND", "message": "Event not found" } }
// DELETE → 204 No Content
```

No frontend code consumed the REST API envelope (`success`/`data` fields), so this is a backend-only change with no client impact.

## Test plan

- [x] Convex type-check passes
- [x] Web type-check passes
- [x] All 368 Convex tests pass
- [x] Lint clean
- [ ] Verify Swagger UI at `/api/v1/docs` reflects new schemas
- [ ] Smoke test a few endpoints with API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)